### PR TITLE
feat(cmd/anirent): execute cmd with context for easy signal handling

### DIFF
--- a/cmd/anirent/cmd/cmd.go
+++ b/cmd/anirent/cmd/cmd.go
@@ -1,13 +1,18 @@
 package cmd
 
 import (
+	"context"
 	"os"
+	"os/signal"
 )
 
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	err := rootCmd.Execute()
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer cancel()
+
+	err := rootCmd.ExecuteContext(ctx)
 	if err != nil {
 		os.Exit(1)
 	}

--- a/cmd/anirent/cmd/download.go
+++ b/cmd/anirent/cmd/download.go
@@ -40,7 +40,7 @@ var downloadCmd = &cobra.Command{
 			return
 		}
 
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(cmd.Context())
 		go func() {
 			defer cancel()
 

--- a/cmd/anirent/cmd/subsplease.go
+++ b/cmd/anirent/cmd/subsplease.go
@@ -56,7 +56,7 @@ var subspleaseCmd = &cobra.Command{
 			return
 		}
 
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(cmd.Context())
 		go func() {
 			defer cancel()
 


### PR DESCRIPTION
Closes #9 